### PR TITLE
Experimentation dash leaflet add county query to osm api

### DIFF
--- a/experimentation/frontend/dash_leaflet/geojson/app.py
+++ b/experimentation/frontend/dash_leaflet/geojson/app.py
@@ -66,6 +66,7 @@ app.layout = html.Div(
                                 )
                             ],
                             name="Climate",
+                            checked=True
                         ),
                     ]
                     + app_layers.get_infrastucture_overlays(),
@@ -131,6 +132,7 @@ def download_csv(n_clicks, shapes, selected_overlays):
             osm_types=list(set(osm_types)),
             osm_subtypes=list(set(osm_subtypes)),
             bbox=shapes,
+            county=True
         )
         gdf = app_utils.geojson_to_geopandas(geojson=data)
         df = pd.DataFrame(gdf)

--- a/experimentation/frontend/dash_leaflet/geojson/pgosm_flex_api.py
+++ b/experimentation/frontend/dash_leaflet/geojson/pgosm_flex_api.py
@@ -334,7 +334,7 @@ class OpenStreetMapDataAPI:
             # TODO: Implement sql.SQL strings for building better sql queries 
             # https://www.psycopg.org/docs/sql.html
 
-            select_statement = f"SELECT t.tags, ST_Transform(main.geom, {srid}) AS geometry"
+            select_statement = f"SELECT main.osm_id, t.tags, ST_Transform(main.geom, {srid}) AS geometry"
             from_statement = f"FROM {self.schema}.{table} main"
             join_statement = f"JOIN {self.schema}.tags t ON main.osm_id = t.osm_id"
             where_clause = "WHERE main.osm_type IN %s" # For now, always require OSM type be specified


### PR DESCRIPTION
Adds parameter to return county name for given feature. This uses an intersection with the place_polygon table, which is loaded into the osm schema by the ETL.