### PR TITLE
Experimentation dash leaflet docker build

### DIFF
--- a/experimentation/frontend/dash_leaflet/geojson/Dockerfile
+++ b/experimentation/frontend/dash_leaflet/geojson/Dockerfile
@@ -27,5 +27,5 @@ COPY pgosm_flex_api.py .
 # Expose the port the app runs on
 EXPOSE 8050
 
-# Run the application
-CMD ["gunicorn", "-b", "0.0.0.0:8050", "app:server"]
+# Run the application using gunicorn
+CMD exec gunicorn -b 0.0.0.0:8050 --workers $GUNICORN_WORKERS app:server

--- a/experimentation/frontend/dash_leaflet/geojson/Dockerfile
+++ b/experimentation/frontend/dash_leaflet/geojson/Dockerfile
@@ -26,6 +26,7 @@ COPY pgosm_flex_api.py .
 
 # Expose the port the app runs on
 EXPOSE 8050
+EXPOSE 80
 
 # Run the application
-CMD ["gunicorn", "-b", "0.0.0.0:8050", "app:server"]
+CMD ["gunicorn", "-b", "0.0.0.0:80", "app:server"]

--- a/experimentation/frontend/dash_leaflet/geojson/Dockerfile
+++ b/experimentation/frontend/dash_leaflet/geojson/Dockerfile
@@ -1,0 +1,31 @@
+FROM python:3.12
+
+# Set working directory
+WORKDIR /app
+
+# Install gdal dependencies
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    libgdal-dev \
+    --fix-missing
+RUN export CPLUS_INCLUDE_PATH=/usr/include/gdal
+RUN export C_INCLUDE_PATH=/usr/include/gdal
+
+# Install dependencies
+RUN pip install GDAL==3.6.2
+COPY requirements.txt requirements.txt
+RUN pip install -r requirements.txt
+
+# Copy the application code
+COPY assets/ ./assets
+COPY app.py .
+COPY app_utils.py .
+COPY app_layers.py .
+COPY app_config.py .
+COPY pgosm_flex_api.py .
+
+# Expose the port the app runs on
+EXPOSE 8050
+
+# Run the application
+CMD ["gunicorn", "-b", "0.0.0.0:8050", "app:server"]

--- a/experimentation/frontend/dash_leaflet/geojson/Dockerfile
+++ b/experimentation/frontend/dash_leaflet/geojson/Dockerfile
@@ -26,7 +26,6 @@ COPY pgosm_flex_api.py .
 
 # Expose the port the app runs on
 EXPOSE 8050
-EXPOSE 80
 
 # Run the application
-CMD ["gunicorn", "-b", "0.0.0.0:80", "app:server"]
+CMD ["gunicorn", "-b", "0.0.0.0:8050", "app:server"]

--- a/experimentation/frontend/dash_leaflet/geojson/README.md
+++ b/experimentation/frontend/dash_leaflet/geojson/README.md
@@ -7,36 +7,29 @@ This directory uses a dash app that shows both infrastructure and climate data v
 The sample climate data in the `experimentation/tile_service/raster_tiler/dynamic/data` directory is % burnt area mean over ~50 years. This can be replaced by a custom COG (Cloud Optimized GeoTIFF) of your choosing. See `experimentation/tile_service/raster_tiler/dynamic/data` for notebook on generating GeoTIFFs for climate data.
 
 
-
 ## How to run
-0. Set up a local postgres instance and load using the steps in `backend/physical-asset/database` and `backend/physical-asset/etl`
+0. Set up a local or remote postgres instance and load using the steps in `backend/physical-asset/database` and `backend/physical-asset/etl`.
 
-1. Navigate to and run the docker compose in `climate-risk-map/experimentation/tile_service` to start the tiling service, which serves the climate tiles.
+1. Navigate to this current directory (`/climate-risk-map/experimentation/frontend/dash_leaflet/geojson`) and build the docker image.
 
-```bash
-docker compose up --build
-```
-
-2. Navigate to `climate-risk-map/experimentation/frontend/dash_leaflet/geojson`, create a conda env, and install necessary packages and activate
+*Note, if the docker build fails because of the build dependencies and an error about "Hash Sum Mismatch", try building on another network or VPN.*
 
 ```bash
-conda env create -f app/environment.yml
+docker build -t climate-risk-map-test .
 ```
+
+2. Create a .env file, following the env.sample file. The TiTiler endpoint is meant to be
+a deployed endpoint. TiTiler deployment on AWS Lambda can be done easily using [this repo and stack.](https://github.com/developmentseed/titiler-lambda-layer)
+
+3. Run a container using the docker image we just built, using the following command
 
 ```bash
-conda activate frontend-geojson-climate
+docker run -p 8050:8050 --rm --env-file .env climate-risk-map-test
 ```
-
-3. Create `.env` file based on `env.sample`. The database details will need to be set based on the database you are connecting to.
-
-4. Run the dash app and go to `http://127.0.0.1:8050/` in your broswer to see the map.
-
-```bash
-python app.py
-```
+4. Go to `http://0.0.0.0:8050/` in your broswer to see the map.
 
 ## Limitations
 
 When experimenting, loading the infrastructure points data as a GeoJSON layer in dash-leaflet proved to crash the browser. This is likely due to the browser trying to render >100k points at once. This shows there is an inherent limitation with using GeoJSON data in the mapping application this way. 
 
-The solution would be to use something like Tegola to serve vector tile data from the PostGIS database. Dash-Leaflet does not support vector tiles. An alternative is to enable clustering, which forces the browser not to render all the features at one time. This does not look as visually appealing as a vector tile approach would. 
+The solution would be to use something like Tegola to serve vector tile data from the PostGIS database. Dash-Leaflet does not support vector tiles. An alternative is to enable clustering, which forces the browser not to render all the features at one time. This does not look as visually appealing as a vector tile approach would. A workaround is setting the cluster icon to transparent, giving the illusion of points generating dynamically.

--- a/experimentation/frontend/dash_leaflet/geojson/app.py
+++ b/experimentation/frontend/dash_leaflet/geojson/app.py
@@ -188,4 +188,4 @@ def download_csv(n_clicks, shapes, selected_overlays):
 
 
 if __name__ == "__main__":
-    app.run_server(host="0.0.0.0", port=80)
+    app.run_server(host="0.0.0.0", port=8050)

--- a/experimentation/frontend/dash_leaflet/geojson/app.py
+++ b/experimentation/frontend/dash_leaflet/geojson/app.py
@@ -1,20 +1,16 @@
-import json
+import os
+
 import dash_leaflet as dl
+
 from psycopg2 import pool
-
 from dash import Dash, Input, Output, html, dcc, no_update, State
-
 from typing import List
 
 import pgosm_flex_api
 import app_utils
 import app_layers
 import app_config
-from dotenv import load_dotenv
-import os
 
-
-load_dotenv()
 PG_DBNAME = os.environ["PG_DBNAME"]
 PG_USER = os.environ["PG_USER"]
 PG_HOST = os.environ["PG_HOST"]
@@ -49,7 +45,8 @@ def close_all_connections():
 
 
 icon_url = "/assets/icon.css"
-app = Dash()
+app = Dash(__name__)
+server = app.server
 # Assumes you are running the docker-compose.yml in the directory
 
 min_climate_value, max_climate_value = app_utils.get_climate_min_max()
@@ -191,4 +188,4 @@ def download_csv(n_clicks, shapes, selected_overlays):
 
 
 if __name__ == "__main__":
-    app.run_server(port=8050, host="127.0.0.1", debug=True)
+    app.run_server()

--- a/experimentation/frontend/dash_leaflet/geojson/app.py
+++ b/experimentation/frontend/dash_leaflet/geojson/app.py
@@ -188,4 +188,4 @@ def download_csv(n_clicks, shapes, selected_overlays):
 
 
 if __name__ == "__main__":
-    app.run_server()
+    app.run_server(host="0.0.0.0", port=80)

--- a/experimentation/frontend/dash_leaflet/geojson/app_layers.py
+++ b/experimentation/frontend/dash_leaflet/geojson/app_layers.py
@@ -3,7 +3,6 @@ import dash_leaflet as dl
 import psycopg2 as pg
 
 from typing import List
-from dotenv import load_dotenv
 
 import app_config
 import app_utils
@@ -11,8 +10,6 @@ import pgosm_flex_api
 
 from dash_extensions.javascript import assign
 
-
-load_dotenv()
 PG_DBNAME = os.environ["PG_DBNAME"]
 PG_USER = os.environ["PG_USER"]
 PG_HOST = os.environ["PG_HOST"]

--- a/experimentation/frontend/dash_leaflet/geojson/app_utils.py
+++ b/experimentation/frontend/dash_leaflet/geojson/app_utils.py
@@ -3,13 +3,10 @@ import httpx
 import os
 import geopandas as gpd
 import pandas as pd
-from dotenv import load_dotenv
 from shapely.geometry import shape
 from dash_extensions.javascript import assign
 
 import app_config
-
-load_dotenv()
 
 TITILER_BASE_ENDPOINT = os.environ["TITILER_BASE_ENDPOINT"]
 FILE_URL = os.environ["FILE_URL"]

--- a/experimentation/frontend/dash_leaflet/geojson/env.sample
+++ b/experimentation/frontend/dash_leaflet/geojson/env.sample
@@ -1,7 +1,8 @@
-TITILER_BASE_ENDPOINT=http://localhost:8000
-FILE_URL=http://raster-tiler-server:8080/OutputCOG.tif
+TITILER_BASE_ENDPOINT=https://aws-api-gateway-url
+FILE_URL=s3://uw-climaterisklab/scratch/OutputCOG.tif
 PG_DBNAME=pgosm_flex_washington
 PG_USER=osm_ro_user
-PG_HOST=localhost
+PG_HOST=host.docker.internal
 PG_PASSWORD=mysecretpassword
 PG_MAX_CONN=15
+GUNICORN_WORKERS=5

--- a/experimentation/frontend/dash_leaflet/geojson/requirements.txt
+++ b/experimentation/frontend/dash_leaflet/geojson/requirements.txt
@@ -5,5 +5,4 @@ dash-extensions==1.0.16
 geopandas==0.14.2
 httpx==0.27.0
 pandas==2.2.1
-python-dotenv
 gunicorn

--- a/experimentation/frontend/dash_leaflet/geojson/requirements.txt
+++ b/experimentation/frontend/dash_leaflet/geojson/requirements.txt
@@ -1,0 +1,9 @@
+psycopg2-binary
+dash==2.17
+dash-leaflet==1.0.15
+dash-extensions==1.0.16
+geopandas==0.14.2
+httpx==0.27.0
+pandas==2.2.1
+python-dotenv
+gunicorn


### PR DESCRIPTION
Creates a docker file to containerize the frontend dash app, using gunicorn to manage production workload. Can be run locally, when pointing to a remote TiTiler endpoint (like API Gateway with Lambda).