### PR TITLE
Frontend app remove geo dependancies

### DIFF
--- a/frontend/app/Dockerfile
+++ b/frontend/app/Dockerfile
@@ -6,7 +6,6 @@ WORKDIR /climate-risk-map/frontend/app
 # Install gdal dependencies
 RUN apt-get update && apt-get install -y \
     build-essential \
-    libgdal-dev \
     --fix-missing
 
 ENV CPLUS_INCLUDE_PATH /usr/include/gdal

--- a/frontend/app/api_sample.py
+++ b/frontend/app/api_sample.py
@@ -80,7 +80,7 @@ if __name__ == "__main__":
         climate_month=[8, 9],
         climate_ssp=126,
         climate_metadata=True,
-        centroid=True
+        centroid=False
     )
     data = api.get_data(input_params=params
     )

--- a/frontend/app/api_sample.py
+++ b/frontend/app/api_sample.py
@@ -2,6 +2,7 @@ import infraxclimate_api
 import os
 import psycopg2
 import time
+import app_utils
 
 PG_DBNAME = os.environ["PG_DBNAME"]
 PG_USER = os.environ["PG_USER"]
@@ -72,7 +73,7 @@ if __name__ == "__main__":
         category="infrastructure",
         osm_types=["power"],
         osm_subtypes=["line"],
-        bbox=bbox,
+        bbox=None,
         county=True,
         city=True,
         climate_variable="burntFractionAll",
@@ -80,7 +81,6 @@ if __name__ == "__main__":
         climate_month=[8, 9],
         climate_ssp=126,
         climate_metadata=True,
-        centroid=False
     )
     data = api.get_data(input_params=params
     )

--- a/frontend/app/app.py
+++ b/frontend/app/app.py
@@ -15,7 +15,7 @@ import app_map
 import app_control_panel
 import app_config
 
-
+TITILER_ENDPOINT = os.environ["TITILER_ENDPOINT"]
 PG_DBNAME = os.environ["PG_DBNAME"]
 PG_USER = os.environ["PG_USER"]
 PG_HOST = os.environ["PG_HOST"]
@@ -195,8 +195,8 @@ def update_climate_tiles(climate_variable, ssp, decade, month, climate_metadata)
     file_url = f"s3://{bucket}/{prefix}/{str(ssp)}/cogs/{climatology_mean_method}/{file}"
 
     tile_url = app_utils.get_tilejson_url(
+        titiler_endpoint=TITILER_ENDPOINT,
         file_url=file_url,
-        climate_variable=climate_variable,
         min_climate_value=min_climate_value,
         max_climate_value=max_climate_value,
         colormap=colormap,

--- a/frontend/app/app.py
+++ b/frontend/app/app.py
@@ -188,7 +188,7 @@ def update_climate_tiles(climate_variable, ssp, decade, month, climate_metadata)
                 unit=unit
             )
     
-    # Generaye S3 URI to COG File
+    # Generate S3 URI to COG File
     bucket = app_config.CLIMATE_DATA[climate_variable]["geotiff"]["s3_bucket"]
     prefix = app_config.CLIMATE_DATA[climate_variable]["geotiff"]["s3_base_prefix"]
     file = f"{decade}-{month:02d}-{state}.tif"

--- a/frontend/app/app_config.py
+++ b/frontend/app/app_config.py
@@ -1,7 +1,7 @@
 from dash_extensions.javascript import arrow_function
 from dash_extensions.javascript import assign
 
-DEFAULT_CLIMATE_VARIABLE = "burntFractionAll" # Climate data to load on app start up
+DEFAULT_CLIMATE_VARIABLE = "burntFractionAll"  # Climate data to load on app start up
 
 CLIMATE_DATA = {
     "burntFractionAll": {
@@ -11,11 +11,10 @@ CLIMATE_DATA = {
             "s3_bucket": "uw-climaterisklab",
             "s3_base_prefix": "climate-risk-map/backend/climate/scenariomip/burntFractionAll",
             "colormap": "ylorbr",
-            "layer_opacity": 0.6
+            "layer_opacity": 0.6,
         },
         "available_ssp": ["ssp126", "ssp245", "ssp370", "ssp585"],
     }
-
 }
 
 MAP_COMPONENT = {
@@ -75,35 +74,11 @@ POWER_GRID_LAYERS = {
                 "fillColor": "#D3D3D3",
                 "fillOpacity": 0.8,
             },
-            "cluster": False,
-            "superClusterOptions": SUPERCLUSTER,
+            "cluster": True,
+            "superClusterOptions": {"radius": 50},
         },
         "geom_types": ["MultiPolygon"],
-        "icon": {"create_points": True, "url": "assets/electric.svg"},
-    },
-    "Power Substations": {
-        "Overlay": {
-            "name": "Power Substations",
-            "id": "power-substation-overlay",
-            "checked": True,
-        },
-        "GeoJSON": {
-            "id": "power-substation-geojson",
-            "category": "infrastructure",
-            "osm_types": ["power"],
-            "osm_subtypes": ["substation"],
-            "hoverStyle": arrow_function(dict(weight=5, color="yellow", dashArray="")),
-            "style": {
-                "color": "#696969",
-                "weight": 2,
-                "fillColor": "#5F9EA0",
-                "fillOpacity": 0.5,
-            },
-            "cluster": True,
-            "superClusterOptions": SUPERCLUSTER,
-        },
-        "geom_types": ["MultiPolygon", "Point"],
-        "icon": {"create_points": False, "url": DEFAULT_POINT_ICON_URL},
+        "icon": {"url": "assets/electric.svg"},
     },
     "Power Lines": {
         "Overlay": {
@@ -157,7 +132,7 @@ POWER_GRID_LAYERS = {
         "Overlay": {
             "name": "Power Generators",
             "id": "power-generator-overlay",
-            "checked": True,
+            "checked": False,
         },
         "GeoJSON": {
             "id": "power-generator-geojson",
@@ -175,13 +150,13 @@ POWER_GRID_LAYERS = {
             "superClusterOptions": SUPERCLUSTER,
         },
         "geom_types": ["MultiPolygon", "Point"],
-        "icon": {"create_points": False, "url": DEFAULT_POINT_ICON_URL},
+        "icon": {"url": DEFAULT_POINT_ICON_URL},
     },
     "Power Transformers": {
         "Overlay": {
             "name": "Power Transformers",
             "id": "power-transformer-overlay",
-            "checked": True,
+            "checked": False,
         },
         "GeoJSON": {
             "id": "power-transformer-geojson",
@@ -199,10 +174,35 @@ POWER_GRID_LAYERS = {
             "superClusterOptions": SUPERCLUSTER,
         },
         "geom_types": ["MultiPolygon", "Point"],
-        "icon": {"create_points": False, "url": DEFAULT_POINT_ICON_URL},
+        "icon": {"url": DEFAULT_POINT_ICON_URL},
+    },
+    "Power Substations": {
+        "Overlay": {
+            "name": "Power Substations",
+            "id": "power-substation-overlay",
+            "checked": False,
+        },
+        "GeoJSON": {
+            "id": "power-substation-geojson",
+            "category": "infrastructure",
+            "osm_types": ["power"],
+            "osm_subtypes": ["substation"],
+            "hoverStyle": arrow_function(dict(weight=5, color="yellow", dashArray="")),
+            "style": {
+                "color": "#696969",
+                "weight": 2,
+                "fillColor": "#5F9EA0",
+                "fillOpacity": 0.5,
+            },
+            "cluster": True,
+            "superClusterOptions": SUPERCLUSTER,
+        },
+        "geom_types": ["MultiPolygon", "Point"],
+        "icon": {"url": DEFAULT_POINT_ICON_URL},
     },
 }
 
+# Javascript code to create a transparent cluster icon
 TRANSPARENT_MARKER_CLUSTER = assign(
     """function(feature, latlng, index, context){
     const scatterIcon = L.DivIcon.extend({

--- a/frontend/app/app_control_panel.py
+++ b/frontend/app/app_control_panel.py
@@ -22,7 +22,7 @@ TITLE_BAR = html.Div(
                 ),
                 dbc.Col(
                     html.Div(
-                        "UW Climate Risk Lab",
+                        "UW Climate Risk Map",
                         style={
                             "color": "#39275B",
                             "font-size": "2vw",  # Scale text size based on viewport width

--- a/frontend/app/app_map.py
+++ b/frontend/app/app_map.py
@@ -1,4 +1,3 @@
-import os
 import dash_leaflet as dl
 import psycopg2 as pg
 
@@ -8,14 +7,7 @@ import app_config
 import app_utils
 import infraxclimate_api
 
-from dash_extensions.javascript import assign
 from dash import html
-
-PG_DBNAME = os.environ["PG_DBNAME"]
-PG_USER = os.environ["PG_USER"]
-PG_HOST = os.environ["PG_HOST"]
-PG_PASSWORD = os.environ["PG_PASSWORD"]
-PG_PORT = os.environ["PG_PORT"]
 
 
 def get_state_overlay(state: str, z_index: int) -> dl.Pane:

--- a/frontend/app/app_map.py
+++ b/frontend/app/app_map.py
@@ -82,84 +82,43 @@ def get_power_grid_overlays(conn: pg.extensions.connection) -> List[dl.Overlay]:
 
         layergroup_children = []
 
-        # We create a separate GeoJSON component for each geom type,
-        # as certain subtypes have multiple geometry types.
-        # This allows a finer level of config for clustering points, which improves performance.
-        # We generally want to cluster Points, and not cluster other geom types
-        for geom_type in subtype_config["geom_types"]:
+        params = infraxclimate_api.infraXclimateInput(
+            category=subtype_config["GeoJSON"]["category"],
+            osm_types=subtype_config["GeoJSON"]["osm_types"],
+            osm_subtypes=subtype_config["GeoJSON"]["osm_subtypes"],
+        )
 
-            params = infraxclimate_api.infraXclimateInput(
-                category=subtype_config["GeoJSON"]["category"],
-                osm_types=subtype_config["GeoJSON"]["osm_types"],
-                osm_subtypes=subtype_config["GeoJSON"]["osm_subtypes"],
-                geom_type=geom_type,
+        data = api.get_data(input_params=params)
+        data = app_utils.create_feature_toolip(geojson=data)
+
+        if subtype_config["GeoJSON"]["cluster"]:
+            data = app_utils.convert_geojson_feature_collection_to_points(geojson=data, preserve_types=["LineString"])
+            cluster = subtype_config["GeoJSON"]["cluster"]
+            clusterToLayer = app_config.TRANSPARENT_MARKER_CLUSTER
+            superClusterOptions = subtype_config["GeoJSON"]["superClusterOptions"]
+
+        else:
+            cluster = False
+            clusterToLayer = None
+            superClusterOptions = False
+
+        if subtype_config["icon"] is not None:
+            pointToLayer = app_utils.create_custom_icon(subtype_config["icon"]["url"])
+        else:
+            pointToLayer = None
+
+        layergroup_children.append(
+            dl.GeoJSON(
+                id=subtype_config["GeoJSON"]["id"],
+                data=data,
+                hoverStyle=subtype_config["GeoJSON"]["hoverStyle"],
+                style=subtype_config["GeoJSON"]["style"],
+                cluster=cluster,
+                clusterToLayer=clusterToLayer,
+                superClusterOptions=superClusterOptions,
+                pointToLayer=pointToLayer,
             )
-
-            data = api.get_data(input_params=params)
-            data = app_utils.create_feature_toolip(geojson=data)
-
-            if geom_type != "Point":
-                cluster = False
-                clusterToLayer = None
-            else:
-                cluster = subtype_config["GeoJSON"]["cluster"]
-                # Javascript code to create a transparent cluster icon
-                clusterToLayer = app_config.TRANSPARENT_MARKER_CLUSTER
-
-            if (subtype_config["icon"] is not None) & (geom_type == "Point"):
-                pointToLayer = app_utils.create_custom_icon(
-                    subtype_config["icon"]["url"]
-                )
-            else:
-                pointToLayer = None
-
-            layergroup_children.append(
-                dl.GeoJSON(
-                    id=subtype_config["GeoJSON"]["id"] + f"-{geom_type}",
-                    data=data,
-                    hoverStyle=subtype_config["GeoJSON"]["hoverStyle"],
-                    style=subtype_config["GeoJSON"]["style"],
-                    cluster=cluster,
-                    clusterToLayer=clusterToLayer,
-                    superClusterOptions=subtype_config["GeoJSON"][
-                        "superClusterOptions"
-                    ],
-                    pointToLayer=pointToLayer,
-                )
-            )
-
-            # This block creates icons for non-points. Above, we create icons for Point geometrys by default
-            # If we want to force a non-Point geometry to display an icon, we flag the "create_points" property
-            # in the config, and provide a url to the icon. This will make a database call and return the centroid to use
-            # as the icon location for the given features.
-            # * NOTE, performance may be an issue if there are too many features are returned
-            if subtype_config["icon"] is not None:
-                if (subtype_config["icon"]["create_points"]) & (geom_type != "Point"):
-                    params = infraxclimate_api.infraXclimateInput(
-                        category=subtype_config["GeoJSON"]["category"],
-                        osm_types=subtype_config["GeoJSON"]["osm_types"],
-                        osm_subtypes=subtype_config["GeoJSON"]["osm_subtypes"],
-                        geom_type=geom_type,
-                        centroid=True,
-                    )
-                    data = api.get_data(input_params=params)
-                    data = app_utils.create_feature_toolip(geojson=data)
-                    layergroup_children.append(
-                        dl.GeoJSON(
-                            id=subtype_config["GeoJSON"]["id"] + f"-icon",
-                            data=data,
-                            hoverStyle=subtype_config["GeoJSON"]["hoverStyle"],
-                            style=subtype_config["GeoJSON"]["style"],
-                            cluster=cluster,
-                            clusterToLayer=clusterToLayer,
-                            superClusterOptions=subtype_config["GeoJSON"][
-                                "superClusterOptions"
-                            ],
-                            pointToLayer=app_utils.create_custom_icon(
-                                subtype_config["icon"]["url"]
-                            ),
-                        )
-                    )
+        )
 
         overlay = dl.Overlay(
             id=subtype_config["Overlay"]["id"],
@@ -221,9 +180,7 @@ def get_map(conn: pg.extensions.connection):
 
     # Default colorscale transparent while callbacks load
     color_bar = html.Div(
-        id=config["color_bar"]["id"] + "-div",
-        style={"display": "none"},
-        children=[]
+        id=config["color_bar"]["id"] + "-div", style={"display": "none"}, children=[]
     )
 
     map = dl.Map(

--- a/frontend/app/app_utils.py
+++ b/frontend/app/app_utils.py
@@ -45,13 +45,12 @@ def get_climate_min_max(file_url: str):
 
 def get_tilejson_url(
     file_url: str,
-    climate_variable: str,
     min_climate_value: str,
     max_climate_value: str,
     colormap: str,
 ):
 
-    endpoint = f"{TITILER_BASE_ENDPOINT}/cog/tilejson.json"
+    endpoint = f"{TITILER_BASE_ENDPOINT}/cog/WebMercatorQuad/tilejson.json"
     params = {
         "tileMatrixSetId": "WebMercatorQuad",
         "url": file_url,

--- a/frontend/app/app_utils.py
+++ b/frontend/app/app_utils.py
@@ -11,14 +11,6 @@ from concurrent.futures import ProcessPoolExecutor
 
 from typing import List, Dict
 
-
-TITILER_BASE_ENDPOINT = os.environ["TITILER_BASE_ENDPOINT"]
-PG_DBNAME = os.environ["PG_DBNAME"]
-PG_USER = os.environ["PG_USER"]
-PG_HOST = os.environ["PG_HOST"]
-PG_PASSWORD = os.environ["PG_PASSWORD"]
-
-
 def query_titiler(endpoint: str, params):
     try:
         r = httpx.get(url=endpoint, params=params)
@@ -31,26 +23,15 @@ def query_titiler(endpoint: str, params):
     return r.json()
 
 
-def get_climate_min_max(file_url: str):
-    endpoint = f"{TITILER_BASE_ENDPOINT}/cog/statistics"
-    params = {"url": file_url, "bidx": [1]}
-    r = query_titiler(endpoint, params)
-
-    # b1 refers to "band 1". Currently the test data is a single band
-    min_climate_value = r["b1"]["min"]
-    max_climate_value = r["b1"]["max"]
-
-    return min_climate_value, max_climate_value
-
-
 def get_tilejson_url(
+    titiler_endpoint: str,
     file_url: str,
     min_climate_value: str,
     max_climate_value: str,
     colormap: str,
 ):
 
-    endpoint = f"{TITILER_BASE_ENDPOINT}/cog/WebMercatorQuad/tilejson.json"
+    endpoint = f"{titiler_endpoint}/cog/WebMercatorQuad/tilejson.json"
     params = {
         "tileMatrixSetId": "WebMercatorQuad",
         "url": file_url,

--- a/frontend/app/app_utils.py
+++ b/frontend/app/app_utils.py
@@ -1,13 +1,9 @@
-import psycopg2
 import httpx
-import os
 import math
 import geopandas as gpd
 import pandas as pd
 from shapely.geometry import shape
-from geojson_pydantic import FeatureCollection
 from dash_extensions.javascript import assign
-from concurrent.futures import ProcessPoolExecutor
 
 from typing import List, Dict
 

--- a/frontend/app/infraxclimate_api.py
+++ b/frontend/app/infraxclimate_api.py
@@ -208,6 +208,13 @@ class infraXclimateAPI:
                 column=sql.Identifier(self.osm_column_geom),
             ),
             sql.SQL(
+                "ST_AsText(ST_Transform({schema}.{table}.{column}, %s), 3) AS geometry_wkt"
+            ).format(
+                schema=sql.Identifier(self.osm_schema),
+                table=sql.Identifier(primary_table),
+                column=sql.Identifier(self.osm_column_geom),
+            ),
+            sql.SQL(
                 "ST_X(ST_Centroid(ST_Transform({schema}.{table}.{column}, %s))) AS longitude"
             ).format(
                 schema=sql.Identifier(self.osm_schema),
@@ -223,7 +230,7 @@ class infraXclimateAPI:
             )
             
         ]
-        params.extend([epsg_code] * 3)
+        params.extend([epsg_code] * 4)
         
 
         # Add extra where clause for subtypes if they are specified

--- a/frontend/app/poetry.lock
+++ b/frontend/app/poetry.lock
@@ -32,25 +32,6 @@ test = ["anyio[trio]", "coverage[toml] (>=7)", "exceptiongroup (>=1.2.0)", "hypo
 trio = ["trio (>=0.26.1)"]
 
 [[package]]
-name = "attrs"
-version = "24.2.0"
-description = "Classes Without Boilerplate"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "attrs-24.2.0-py3-none-any.whl", hash = "sha256:81921eb96de3191c8258c199618104dd27ac608d9366f5e35d011eae1867ede2"},
-    {file = "attrs-24.2.0.tar.gz", hash = "sha256:5cfb1b9148b5b086569baec03f20d7b6bf3bcacc9a42bebf87ffaaca362f6346"},
-]
-
-[package.extras]
-benchmark = ["cloudpickle", "hypothesis", "mypy (>=1.11.1)", "pympler", "pytest (>=4.3.0)", "pytest-codspeed", "pytest-mypy-plugins", "pytest-xdist[psutil]"]
-cov = ["cloudpickle", "coverage[toml] (>=5.3)", "hypothesis", "mypy (>=1.11.1)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "pytest-xdist[psutil]"]
-dev = ["cloudpickle", "hypothesis", "mypy (>=1.11.1)", "pre-commit", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "pytest-xdist[psutil]"]
-docs = ["cogapp", "furo", "myst-parser", "sphinx", "sphinx-notfound-page", "sphinxcontrib-towncrier", "towncrier (<24.7)"]
-tests = ["cloudpickle", "hypothesis", "mypy (>=1.11.1)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "pytest-xdist[psutil]"]
-tests-mypy = ["mypy (>=1.11.1)", "pytest-mypy-plugins"]
-
-[[package]]
 name = "blinker"
 version = "1.8.2"
 description = "Fast, simple object-to-object and broadcast signaling"
@@ -195,40 +176,6 @@ files = [
 
 [package.dependencies]
 colorama = {version = "*", markers = "platform_system == \"Windows\""}
-
-[[package]]
-name = "click-plugins"
-version = "1.1.1"
-description = "An extension module for click to enable registering CLI commands via setuptools entry-points."
-optional = false
-python-versions = "*"
-files = [
-    {file = "click-plugins-1.1.1.tar.gz", hash = "sha256:46ab999744a9d831159c3411bb0c79346d94a444df9a3a3742e9ed63645f264b"},
-    {file = "click_plugins-1.1.1-py2.py3-none-any.whl", hash = "sha256:5d262006d3222f5057fd81e1623d4443e41dcda5dc815c06b442aa3c02889fc8"},
-]
-
-[package.dependencies]
-click = ">=4.0"
-
-[package.extras]
-dev = ["coveralls", "pytest (>=3.6)", "pytest-cov", "wheel"]
-
-[[package]]
-name = "cligj"
-version = "0.7.2"
-description = "Click params for commmand line interfaces to GeoJSON"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, <4"
-files = [
-    {file = "cligj-0.7.2-py3-none-any.whl", hash = "sha256:c1ca117dbce1fe20a5809dc96f01e1c2840f6dcc939b3ddbb1111bf330ba82df"},
-    {file = "cligj-0.7.2.tar.gz", hash = "sha256:a4bc13d623356b373c2c27c53dbd9c68cae5d526270bfa71f6c6fa69669c6b27"},
-]
-
-[package.dependencies]
-click = ">=4.0"
-
-[package.extras]
-test = ["pytest-cov"]
 
 [[package]]
 name = "colorama"
@@ -393,53 +340,6 @@ files = [
 ]
 
 [[package]]
-name = "fiona"
-version = "1.10.1"
-description = "Fiona reads and writes spatial data files"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "fiona-1.10.1-cp310-cp310-macosx_10_15_x86_64.whl", hash = "sha256:6e2a94beebda24e5db8c3573fe36110d474d4a12fac0264a3e083c75e9d63829"},
-    {file = "fiona-1.10.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:fc7366f99bdc18ec99441b9e50246fdf5e72923dc9cbb00267b2bf28edd142ba"},
-    {file = "fiona-1.10.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8c32f424b0641c79f4036b96c2e80322fb181b4e415c8cd02d182baef55e6730"},
-    {file = "fiona-1.10.1-cp310-cp310-win_amd64.whl", hash = "sha256:9a67bd88918e87d64168bc9c00d9816d8bb07353594b5ce6c57252979d5dc86e"},
-    {file = "fiona-1.10.1-cp311-cp311-macosx_10_15_x86_64.whl", hash = "sha256:98fe556058b370da07a84f6537c286f87eb4af2343d155fbd3fba5d38ac17ed7"},
-    {file = "fiona-1.10.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:be29044d4aeebae92944b738160dc5f9afc4cdf04f551d59e803c5b910e17520"},
-    {file = "fiona-1.10.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:94bd3d448f09f85439e4b77c38b9de1aebe3eef24acc72bd631f75171cdfde51"},
-    {file = "fiona-1.10.1-cp311-cp311-win_amd64.whl", hash = "sha256:30594c0cd8682c43fd01e7cdbe000f94540f8fa3b7cb5901e805c88c4ff2058b"},
-    {file = "fiona-1.10.1-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:7338b8c68beb7934bde4ec9f49eb5044e5e484b92d940bc3ec27defdb2b06c67"},
-    {file = "fiona-1.10.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8c77fcfd3cdb0d3c97237965f8c60d1696a64923deeeb2d0b9810286cbe25911"},
-    {file = "fiona-1.10.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:537872cbc9bda7fcdf73851c91bc5338fca2b502c4c17049ccecaa13cde1f18f"},
-    {file = "fiona-1.10.1-cp312-cp312-win_amd64.whl", hash = "sha256:41cde2c52c614457e9094ea44b0d30483540789e62fe0fa758c2a2963e980817"},
-    {file = "fiona-1.10.1-cp313-cp313-macosx_10_15_x86_64.whl", hash = "sha256:a00b05935c9900678b2ca660026b39efc4e4b916983915d595964eb381763ae7"},
-    {file = "fiona-1.10.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f78b781d5bcbbeeddf1d52712f33458775dbb9fd1b2a39882c83618348dd730f"},
-    {file = "fiona-1.10.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:29ceeb38e3cd30d91d68858d0817a1bb0c4f96340d334db4b16a99edb0902d35"},
-    {file = "fiona-1.10.1-cp313-cp313-win_amd64.whl", hash = "sha256:15751c90e29cee1e01fcfedf42ab85987e32f0b593cf98d88ed52199ef5ca623"},
-    {file = "fiona-1.10.1-cp38-cp38-macosx_10_15_x86_64.whl", hash = "sha256:6f1242f872dc33d3b4269dcaebf1838a359f9097e1cc848b0e11367bce010e4d"},
-    {file = "fiona-1.10.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:65308b7a7e57fcc533de8a5855b0fce798faabc736d1340192dd8673ff61bc4e"},
-    {file = "fiona-1.10.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:632bc146355af5ff0d77e34ebd1be5072d623b4aedb754b94a3d8c356c4545ac"},
-    {file = "fiona-1.10.1-cp38-cp38-win_amd64.whl", hash = "sha256:b7b4c3c97b1d64a1b3321577e9edaebbd36b64006e278f225f300c497cc87c35"},
-    {file = "fiona-1.10.1-cp39-cp39-macosx_10_15_x86_64.whl", hash = "sha256:b62aa8d5a0981bd33d81c247219b1eaa1e655e0a0682b3a4759fccc40954bb30"},
-    {file = "fiona-1.10.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:f4b19cb5bd22443ef439b39239272349023556994242a8f953a0147684e1c47f"},
-    {file = "fiona-1.10.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fa7e7e5ad252ef29905384bf92e7d14dd5374584b525632652c2ab8925304670"},
-    {file = "fiona-1.10.1-cp39-cp39-win_amd64.whl", hash = "sha256:4e82d18acbe55230e9cf8ede2a836d99ea96b7c0cc7d2b8b993e6c9f0ac14dc2"},
-    {file = "fiona-1.10.1.tar.gz", hash = "sha256:b00ae357669460c6491caba29c2022ff0acfcbde86a95361ea8ff5cd14a86b68"},
-]
-
-[package.dependencies]
-attrs = ">=19.2.0"
-certifi = "*"
-click = ">=8.0,<9.0"
-click-plugins = ">=1.0"
-cligj = ">=0.5"
-
-[package.extras]
-all = ["fiona[calc,s3,test]"]
-calc = ["pyparsing", "shapely"]
-s3 = ["boto3 (>=1.3.1)"]
-test = ["aiohttp", "fiona[s3]", "fsspec", "pytest (>=7)", "pytest-cov", "pytz"]
-
-[[package]]
 name = "flask"
 version = "3.0.3"
 description = "A simple framework for building complex web applications."
@@ -477,19 +377,6 @@ cachelib = ">=0.9.0,<0.10.0"
 Flask = "*"
 
 [[package]]
-name = "gdal"
-version = "3.6.2"
-description = "GDAL: Geospatial Data Abstraction Library"
-optional = false
-python-versions = ">=3.6.0"
-files = [
-    {file = "GDAL-3.6.2.tar.gz", hash = "sha256:a167cde1813707d91a938dad1a22f280f5ad28c45980d42e948fb8c59f890f5a"},
-]
-
-[package.extras]
-numpy = ["numpy (>1.0.0)"]
-
-[[package]]
 name = "geojson-pydantic"
 version = "1.1.1"
 description = "Pydantic data models for the GeoJSON spec."
@@ -507,24 +394,6 @@ pydantic = ">=2.0,<3.0"
 dev = ["bump-my-version", "pre-commit"]
 docs = ["mkdocs", "mkdocs-material", "pygments"]
 test = ["pytest", "pytest-cov", "shapely"]
-
-[[package]]
-name = "geopandas"
-version = "0.14.0"
-description = "Geographic pandas extensions"
-optional = false
-python-versions = ">=3.9"
-files = [
-    {file = "geopandas-0.14.0-py3-none-any.whl", hash = "sha256:a402a565e727642cb44a500c911f226eea26c1b1247c6586827031e3d7a9403a"},
-    {file = "geopandas-0.14.0.tar.gz", hash = "sha256:ea6c031889e1e1888aecaa6e182ca620d78f63551c49b3002a998bcbb280531f"},
-]
-
-[package.dependencies]
-fiona = ">=1.8.21"
-packaging = "*"
-pandas = ">=1.4.0"
-pyproj = ">=3.3.0"
-shapely = ">=1.8.0"
 
 [[package]]
 name = "gunicorn"
@@ -1145,45 +1014,6 @@ files = [
 typing-extensions = ">=4.6.0,<4.7.0 || >4.7.0"
 
 [[package]]
-name = "pyproj"
-version = "3.6.1"
-description = "Python interface to PROJ (cartographic projections and coordinate transformations library)"
-optional = false
-python-versions = ">=3.9"
-files = [
-    {file = "pyproj-3.6.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:ab7aa4d9ff3c3acf60d4b285ccec134167a948df02347585fdd934ebad8811b4"},
-    {file = "pyproj-3.6.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:4bc0472302919e59114aa140fd7213c2370d848a7249d09704f10f5b062031fe"},
-    {file = "pyproj-3.6.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5279586013b8d6582e22b6f9e30c49796966770389a9d5b85e25a4223286cd3f"},
-    {file = "pyproj-3.6.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:80fafd1f3eb421694857f254a9bdbacd1eb22fc6c24ca74b136679f376f97d35"},
-    {file = "pyproj-3.6.1-cp310-cp310-win32.whl", hash = "sha256:c41e80ddee130450dcb8829af7118f1ab69eaf8169c4bf0ee8d52b72f098dc2f"},
-    {file = "pyproj-3.6.1-cp310-cp310-win_amd64.whl", hash = "sha256:db3aedd458e7f7f21d8176f0a1d924f1ae06d725228302b872885a1c34f3119e"},
-    {file = "pyproj-3.6.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ebfbdbd0936e178091309f6cd4fcb4decd9eab12aa513cdd9add89efa3ec2882"},
-    {file = "pyproj-3.6.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:447db19c7efad70ff161e5e46a54ab9cc2399acebb656b6ccf63e4bc4a04b97a"},
-    {file = "pyproj-3.6.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e7e13c40183884ec7f94eb8e0f622f08f1d5716150b8d7a134de48c6110fee85"},
-    {file = "pyproj-3.6.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:65ad699e0c830e2b8565afe42bd58cc972b47d829b2e0e48ad9638386d994915"},
-    {file = "pyproj-3.6.1-cp311-cp311-win32.whl", hash = "sha256:8b8acc31fb8702c54625f4d5a2a6543557bec3c28a0ef638778b7ab1d1772132"},
-    {file = "pyproj-3.6.1-cp311-cp311-win_amd64.whl", hash = "sha256:38a3361941eb72b82bd9a18f60c78b0df8408416f9340521df442cebfc4306e2"},
-    {file = "pyproj-3.6.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:1e9fbaf920f0f9b4ee62aab832be3ae3968f33f24e2e3f7fbb8c6728ef1d9746"},
-    {file = "pyproj-3.6.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6d227a865356f225591b6732430b1d1781e946893789a609bb34f59d09b8b0f8"},
-    {file = "pyproj-3.6.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:83039e5ae04e5afc974f7d25ee0870a80a6bd6b7957c3aca5613ccbe0d3e72bf"},
-    {file = "pyproj-3.6.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fffb059ba3bced6f6725961ba758649261d85ed6ce670d3e3b0a26e81cf1aa8d"},
-    {file = "pyproj-3.6.1-cp312-cp312-win32.whl", hash = "sha256:2d6ff73cc6dbbce3766b6c0bce70ce070193105d8de17aa2470009463682a8eb"},
-    {file = "pyproj-3.6.1-cp312-cp312-win_amd64.whl", hash = "sha256:7a27151ddad8e1439ba70c9b4b2b617b290c39395fa9ddb7411ebb0eb86d6fb0"},
-    {file = "pyproj-3.6.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:4ba1f9b03d04d8cab24d6375609070580a26ce76eaed54631f03bab00a9c737b"},
-    {file = "pyproj-3.6.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:18faa54a3ca475bfe6255156f2f2874e9a1c8917b0004eee9f664b86ccc513d3"},
-    {file = "pyproj-3.6.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fd43bd9a9b9239805f406fd82ba6b106bf4838d9ef37c167d3ed70383943ade1"},
-    {file = "pyproj-3.6.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:50100b2726a3ca946906cbaa789dd0749f213abf0cbb877e6de72ca7aa50e1ae"},
-    {file = "pyproj-3.6.1-cp39-cp39-win32.whl", hash = "sha256:9274880263256f6292ff644ca92c46d96aa7e57a75c6df3f11d636ce845a1877"},
-    {file = "pyproj-3.6.1-cp39-cp39-win_amd64.whl", hash = "sha256:36b64c2cb6ea1cc091f329c5bd34f9c01bb5da8c8e4492c709bda6a09f96808f"},
-    {file = "pyproj-3.6.1-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:fd93c1a0c6c4aedc77c0fe275a9f2aba4d59b8acf88cebfc19fe3c430cfabf4f"},
-    {file = "pyproj-3.6.1-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6420ea8e7d2a88cb148b124429fba8cd2e0fae700a2d96eab7083c0928a85110"},
-    {file = "pyproj-3.6.1.tar.gz", hash = "sha256:44aa7c704c2b7d8fb3d483bbf75af6cb2350d30a63b144279a09b75fead501bf"},
-]
-
-[package.dependencies]
-certifi = "*"
-
-[[package]]
 name = "pytest"
 version = "8.3.3"
 description = "pytest: simple powerful testing with Python"
@@ -1310,64 +1140,6 @@ test = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "ini2toml[lite] (>=
 type = ["importlib-metadata (>=7.0.2)", "jaraco.develop (>=7.21)", "mypy (==1.11.*)", "pytest-mypy"]
 
 [[package]]
-name = "shapely"
-version = "2.0.6"
-description = "Manipulation and analysis of geometric objects"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "shapely-2.0.6-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:29a34e068da2d321e926b5073539fd2a1d4429a2c656bd63f0bd4c8f5b236d0b"},
-    {file = "shapely-2.0.6-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e1c84c3f53144febf6af909d6b581bc05e8785d57e27f35ebaa5c1ab9baba13b"},
-    {file = "shapely-2.0.6-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2ad2fae12dca8d2b727fa12b007e46fbc522148a584f5d6546c539f3464dccde"},
-    {file = "shapely-2.0.6-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b3304883bd82d44be1b27a9d17f1167fda8c7f5a02a897958d86c59ec69b705e"},
-    {file = "shapely-2.0.6-cp310-cp310-win32.whl", hash = "sha256:3ec3a0eab496b5e04633a39fa3d5eb5454628228201fb24903d38174ee34565e"},
-    {file = "shapely-2.0.6-cp310-cp310-win_amd64.whl", hash = "sha256:28f87cdf5308a514763a5c38de295544cb27429cfa655d50ed8431a4796090c4"},
-    {file = "shapely-2.0.6-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:5aeb0f51a9db176da9a30cb2f4329b6fbd1e26d359012bb0ac3d3c7781667a9e"},
-    {file = "shapely-2.0.6-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:9a7a78b0d51257a367ee115f4d41ca4d46edbd0dd280f697a8092dd3989867b2"},
-    {file = "shapely-2.0.6-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f32c23d2f43d54029f986479f7c1f6e09c6b3a19353a3833c2ffb226fb63a855"},
-    {file = "shapely-2.0.6-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b3dc9fb0eb56498912025f5eb352b5126f04801ed0e8bdbd867d21bdbfd7cbd0"},
-    {file = "shapely-2.0.6-cp311-cp311-win32.whl", hash = "sha256:d93b7e0e71c9f095e09454bf18dad5ea716fb6ced5df3cb044564a00723f339d"},
-    {file = "shapely-2.0.6-cp311-cp311-win_amd64.whl", hash = "sha256:c02eb6bf4cfb9fe6568502e85bb2647921ee49171bcd2d4116c7b3109724ef9b"},
-    {file = "shapely-2.0.6-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:cec9193519940e9d1b86a3b4f5af9eb6910197d24af02f247afbfb47bcb3fab0"},
-    {file = "shapely-2.0.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:83b94a44ab04a90e88be69e7ddcc6f332da7c0a0ebb1156e1c4f568bbec983c3"},
-    {file = "shapely-2.0.6-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:537c4b2716d22c92036d00b34aac9d3775e3691f80c7aa517c2c290351f42cd8"},
-    {file = "shapely-2.0.6-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:98fea108334be345c283ce74bf064fa00cfdd718048a8af7343c59eb40f59726"},
-    {file = "shapely-2.0.6-cp312-cp312-win32.whl", hash = "sha256:42fd4cd4834747e4990227e4cbafb02242c0cffe9ce7ef9971f53ac52d80d55f"},
-    {file = "shapely-2.0.6-cp312-cp312-win_amd64.whl", hash = "sha256:665990c84aece05efb68a21b3523a6b2057e84a1afbef426ad287f0796ef8a48"},
-    {file = "shapely-2.0.6-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:42805ef90783ce689a4dde2b6b2f261e2c52609226a0438d882e3ced40bb3013"},
-    {file = "shapely-2.0.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:6d2cb146191a47bd0cee8ff5f90b47547b82b6345c0d02dd8b25b88b68af62d7"},
-    {file = "shapely-2.0.6-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e3fdef0a1794a8fe70dc1f514440aa34426cc0ae98d9a1027fb299d45741c381"},
-    {file = "shapely-2.0.6-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2c665a0301c645615a107ff7f52adafa2153beab51daf34587170d85e8ba6805"},
-    {file = "shapely-2.0.6-cp313-cp313-win32.whl", hash = "sha256:0334bd51828f68cd54b87d80b3e7cee93f249d82ae55a0faf3ea21c9be7b323a"},
-    {file = "shapely-2.0.6-cp313-cp313-win_amd64.whl", hash = "sha256:d37d070da9e0e0f0a530a621e17c0b8c3c9d04105655132a87cfff8bd77cc4c2"},
-    {file = "shapely-2.0.6-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:fa7468e4f5b92049c0f36d63c3e309f85f2775752e076378e36c6387245c5462"},
-    {file = "shapely-2.0.6-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ed5867e598a9e8ac3291da6cc9baa62ca25706eea186117034e8ec0ea4355653"},
-    {file = "shapely-2.0.6-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:81d9dfe155f371f78c8d895a7b7f323bb241fb148d848a2bf2244f79213123fe"},
-    {file = "shapely-2.0.6-cp37-cp37m-win32.whl", hash = "sha256:fbb7bf02a7542dba55129062570211cfb0defa05386409b3e306c39612e7fbcc"},
-    {file = "shapely-2.0.6-cp37-cp37m-win_amd64.whl", hash = "sha256:837d395fac58aa01aa544495b97940995211e3e25f9aaf87bc3ba5b3a8cd1ac7"},
-    {file = "shapely-2.0.6-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:c6d88ade96bf02f6bfd667ddd3626913098e243e419a0325ebef2bbd481d1eb6"},
-    {file = "shapely-2.0.6-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:8b3b818c4407eaa0b4cb376fd2305e20ff6df757bf1356651589eadc14aab41b"},
-    {file = "shapely-2.0.6-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1bbc783529a21f2bd50c79cef90761f72d41c45622b3e57acf78d984c50a5d13"},
-    {file = "shapely-2.0.6-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2423f6c0903ebe5df6d32e0066b3d94029aab18425ad4b07bf98c3972a6e25a1"},
-    {file = "shapely-2.0.6-cp38-cp38-win32.whl", hash = "sha256:2de00c3bfa80d6750832bde1d9487e302a6dd21d90cb2f210515cefdb616e5f5"},
-    {file = "shapely-2.0.6-cp38-cp38-win_amd64.whl", hash = "sha256:3a82d58a1134d5e975f19268710e53bddd9c473743356c90d97ce04b73e101ee"},
-    {file = "shapely-2.0.6-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:392f66f458a0a2c706254f473290418236e52aa4c9b476a072539d63a2460595"},
-    {file = "shapely-2.0.6-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:eba5bae271d523c938274c61658ebc34de6c4b33fdf43ef7e938b5776388c1be"},
-    {file = "shapely-2.0.6-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7060566bc4888b0c8ed14b5d57df8a0ead5c28f9b69fb6bed4476df31c51b0af"},
-    {file = "shapely-2.0.6-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b02154b3e9d076a29a8513dffcb80f047a5ea63c897c0cd3d3679f29363cf7e5"},
-    {file = "shapely-2.0.6-cp39-cp39-win32.whl", hash = "sha256:44246d30124a4f1a638a7d5419149959532b99dfa25b54393512e6acc9c211ac"},
-    {file = "shapely-2.0.6-cp39-cp39-win_amd64.whl", hash = "sha256:2b542d7f1dbb89192d3512c52b679c822ba916f93479fa5d4fc2fe4fa0b3c9e8"},
-    {file = "shapely-2.0.6.tar.gz", hash = "sha256:997f6159b1484059ec239cacaa53467fd8b5564dabe186cd84ac2944663b0bf6"},
-]
-
-[package.dependencies]
-numpy = ">=1.14,<3"
-
-[package.extras]
-docs = ["matplotlib", "numpydoc (==1.1.*)", "sphinx", "sphinx-book-theme", "sphinx-remove-toctrees"]
-test = ["pytest", "pytest-cov"]
-
-[[package]]
 name = "six"
 version = "1.16.0"
 description = "Python 2 and 3 compatibility utilities"
@@ -1482,4 +1254,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "29eef220a8fccd8d2240fc2cf7965179ba38e72275c66bbe09cf3320e07cab73"
+content-hash = "7d639c6e1a05f37a88cabb0ce8e972ff8f8a0ebedcee5950ac4720fbf8fd3bc7"

--- a/frontend/app/pyproject.toml
+++ b/frontend/app/pyproject.toml
@@ -8,14 +8,12 @@ readme = "README.md"
 [tool.poetry.dependencies]
 python = "^3.12"
 pytest = "^8.3.3"
-gdal = "3.6.2"
 
 [tool.poetry.group.dev.dependencies]
 psycopg2-binary = "^2.9.9"
 dash = "2.17"
 dash-leaflet = "1.0.15"
 dash-extensions = "1.0.16"
-geopandas = "0.14"
 httpx = "^0.27.2"
 pandas = "2.2"
 dash-bootstrap-components = "1.6"

--- a/frontend/app/tests/test_app_utils.py
+++ b/frontend/app/tests/test_app_utils.py
@@ -1,0 +1,191 @@
+import pytest
+from unittest.mock import patch, MagicMock
+import httpx
+import geopandas as gpd
+import pandas as pd
+from shapely.geometry import Point, Polygon
+from concurrent.futures import ThreadPoolExecutor
+
+# Import the module functions
+from app.app_utils import (
+    geojson_to_geopandas,
+    create_feature_toolip,
+    process_output_csv,
+    create_custom_icon,
+    convert_geojson_feature_collection_to_points,
+    calc_bbox_area,
+)
+
+# Sample data for testing
+SAMPLE_GEOJSON = {
+    "type": "FeatureCollection",
+    "features": [
+        {
+            "type": "Feature",
+            "properties": {
+                "tags": {"name": "Sample Point", "type": "Point of Interest"},
+                "latitude": 45.0,
+                "longitude": -120.0,
+            },
+            "geometry": {"type": "Point", "coordinates": [-120.0, 10.0]},
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "tags": {"name": "Sample LineString", "type": "Point of Interest"},
+                "latitude": 45.0,
+                "longitude": -120.0,
+            },
+            "geometry": {
+                "type": "LineString",
+                "coordinates": [[-120.0, 10.0], [-119.0, 11.0], [-118.0, 12.0]],
+            },
+        },
+    ],
+}
+
+SAMPLE_GEOJSON_NO_TAGS = {
+    "type": "FeatureCollection",
+    "features": [
+        {
+            "type": "Feature",
+            "properties": {},
+            "geometry": {"type": "Point", "coordinates": [20.0, 10.0]},
+        }
+    ],
+}
+
+SAMPLE_FEATURE = [
+    {
+        "type": "Feature",
+        "properties": {
+            "_bounds": [
+                {"lat": 10.0, "lng": 20.0},
+                {"lat": 15.0, "lng": 25.0},
+            ]
+        },
+    }
+]
+
+
+def test_geojson_to_geopandas():
+    gdf = geojson_to_geopandas(SAMPLE_GEOJSON)
+    assert isinstance(gdf, gpd.GeoDataFrame)
+    assert not gdf.empty
+    assert "geometry" in gdf.columns
+
+
+def test_geojson_to_geopandas_empty():
+    empty_geojson = {"type": "FeatureCollection", "features": []}
+    gdf = geojson_to_geopandas(empty_geojson)
+    assert isinstance(gdf, gpd.GeoDataFrame)
+    assert gdf.empty
+
+
+def test_create_feature_toolip():
+    geojson_with_tooltip = create_feature_toolip(SAMPLE_GEOJSON.copy())
+    tooltip = geojson_with_tooltip["features"][0]["properties"]["tooltip"]
+    assert "<b>name<b>: Sample Point<br><b>type<b>: Point of Interest<br>" == tooltip
+
+
+def test_create_feature_toolip_no_tags():
+    with pytest.raises(ValueError):
+        create_feature_toolip(SAMPLE_GEOJSON_NO_TAGS.copy())
+
+
+def test_process_output_csv():
+    df = process_output_csv(SAMPLE_GEOJSON)
+    assert isinstance(df, pd.DataFrame)
+    assert "latitude" in df.columns
+    assert "longitude" in df.columns
+
+
+def test_process_output_csv_no_features():
+    data = {"type": "FeatureCollection", "features": None}
+    df = process_output_csv(data)
+    assert isinstance(df, pd.DataFrame)
+    assert df.empty
+
+
+@pytest.mark.parametrize(
+    "geojson, preserve_types, expected_output",
+    [
+        (
+            SAMPLE_GEOJSON.copy(),
+            [],
+            {
+                "type": "FeatureCollection",
+                "features": [
+                    {
+                        "type": "Feature",
+                        "properties": {
+                            "tags": {
+                                "name": "Sample Point",
+                                "type": "Point of Interest",
+                            },
+                            "latitude": 40.0,
+                            "longitude": -120.0,
+                        },
+                        "geometry": {"type": "Point", "coordinates": [-120.0, 40.0]},
+                    },
+                    {
+                        "type": "Feature",
+                        "properties": {
+                            "tags": {
+                                "name": "Sample LineString",
+                                "type": "Point of Interest",
+                            },
+                            "latitude": 45.0,
+                            "longitude": -120.0,
+                        },
+                        "geometry": {"type": "Point", "coordinates": [-120.0, 45.0]},
+                    },
+                ],
+            },
+        )
+    ],
+)
+def test_convert_geojson_feature_collection_to_points(
+    geojson, preserve_types, expected_output
+):
+    converted_geojson = convert_geojson_feature_collection_to_points(
+        geojson=geojson, preserve_types=preserve_types
+    )
+    assert converted_geojson == expected_output
+
+
+def test_convert_geojson_preserve_types():
+    sample_line_geojson = {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "properties": {"latitude": 10.0, "longitude": 20.0},
+                "geometry": {
+                    "type": "LineString",
+                    "coordinates": [[20.0, 10.0], [21.0, 11.0]],
+                },
+            }
+        ],
+    }
+    converted_geojson = convert_geojson_feature_collection_to_points(
+        sample_line_geojson, preserve_types=["LineString"]
+    )
+    assert converted_geojson["features"][0]["geometry"]["type"] == "LineString"
+
+
+def test_calc_bbox_area():
+    area = calc_bbox_area(sample_features_with_bounds)
+    expected_area = 6103.515  # Calculated manually for these coordinates
+    assert pytest.approx(area, 0.1) == expected_area
+
+
+def test_calc_bbox_area_no_features():
+    area = calc_bbox_area([])
+    assert area == 0
+
+
+def test_calc_bbox_area_invalid_feature():
+    invalid_feature = {"type": "Invalid", "properties": {}}
+    area = calc_bbox_area([invalid_feature])
+    assert area == 0

--- a/frontend/app/tests/test_app_utils.py
+++ b/frontend/app/tests/test_app_utils.py
@@ -1,11 +1,10 @@
 import pytest
 import copy
-import geopandas as gpd
 import pandas as pd
 
 # Import the module functions
 from app.app_utils import (
-    geojson_to_geopandas,
+    geojson_to_pandas,
     create_feature_toolip,
     process_output_csv,
     convert_geojson_feature_collection_to_points,
@@ -22,6 +21,7 @@ SAMPLE_GEOJSON = {
                 "tags": {"name": "Sample Point", "type": "Point of Interest"},
                 "latitude": 40.0,
                 "longitude": -120.0,
+                "geometry_wkt": "POINT(-120.0, 40.0)"
             },
             "geometry": {"type": "Point", "coordinates": [-120.0, 40.0]},
         },
@@ -31,6 +31,7 @@ SAMPLE_GEOJSON = {
                 "tags": {"name": "Sample LineString", "type": "Point of Interest"},
                 "latitude": 45.0,
                 "longitude": -120.0,
+                "geometry_wkt": "LINESTRING(-120.0 10.0, -119.0 11.0, -118.0 12.0)"
             },
             "geometry": {
                 "type": "LineString",
@@ -52,18 +53,18 @@ SAMPLE_GEOJSON_NO_TAGS = {
 }
 
 
-def test_geojson_to_geopandas():
-    gdf = geojson_to_geopandas(copy.deepcopy(SAMPLE_GEOJSON))
-    assert isinstance(gdf, gpd.GeoDataFrame)
-    assert not gdf.empty
-    assert "geometry" in gdf.columns
+def test_geojson_to_pandas():
+    df = geojson_to_pandas(copy.deepcopy(SAMPLE_GEOJSON))
+    assert isinstance(df, pd.DataFrame)
+    assert not df.empty
+    assert "geometry_wkt" in df.columns
 
 
-def test_geojson_to_geopandas_empty():
+def test_geojson_to_pandas_empty():
     empty_geojson = {"type": "FeatureCollection", "features": []}
-    gdf = geojson_to_geopandas(empty_geojson)
-    assert isinstance(gdf, gpd.GeoDataFrame)
-    assert gdf.empty
+    df = geojson_to_pandas(empty_geojson)
+    assert isinstance(df, pd.DataFrame)
+    assert df.empty
 
 
 def test_create_feature_toolip():
@@ -109,6 +110,7 @@ def test_process_output_csv_no_features():
                             },
                             "latitude": 40.0,
                             "longitude": -120.0,
+                            "geometry_wkt": "POINT(-120.0, 40.0)"
                         },
                         "geometry": {"type": "Point", "coordinates": [-120.0, 40.0]},
                     },
@@ -121,6 +123,7 @@ def test_process_output_csv_no_features():
                             },
                             "latitude": 45.0,
                             "longitude": -120.0,
+                            "geometry_wkt": "LINESTRING(-120.0 10.0, -119.0 11.0, -118.0 12.0)"
                         },
                         "geometry": {"type": "Point", "coordinates": [-120.0, 45.0]},
                     },
@@ -142,6 +145,7 @@ def test_process_output_csv_no_features():
                             },
                             "latitude": 40.0,
                             "longitude": -120.0,
+                            "geometry_wkt": "POINT(-120.0, 40.0)"
                         },
                         "geometry": {"type": "Point", "coordinates": [-120.0, 40.0]},
                     },
@@ -154,6 +158,7 @@ def test_process_output_csv_no_features():
                             },
                             "latitude": 45.0,
                             "longitude": -120.0,
+                            "geometry_wkt": "LINESTRING(-120.0 10.0, -119.0 11.0, -118.0 12.0)"
                         },
                         "geometry": {
                             "type": "LineString",

--- a/frontend/app/tests/test_app_utils.py
+++ b/frontend/app/tests/test_app_utils.py
@@ -1,4 +1,5 @@
 import pytest
+import copy
 import geopandas as gpd
 import pandas as pd
 
@@ -52,7 +53,7 @@ SAMPLE_GEOJSON_NO_TAGS = {
 
 
 def test_geojson_to_geopandas():
-    gdf = geojson_to_geopandas(SAMPLE_GEOJSON)
+    gdf = geojson_to_geopandas(copy.deepcopy(SAMPLE_GEOJSON))
     assert isinstance(gdf, gpd.GeoDataFrame)
     assert not gdf.empty
     assert "geometry" in gdf.columns
@@ -66,18 +67,18 @@ def test_geojson_to_geopandas_empty():
 
 
 def test_create_feature_toolip():
-    geojson_with_tooltip = create_feature_toolip(SAMPLE_GEOJSON.copy())
+    geojson_with_tooltip = create_feature_toolip(copy.deepcopy(SAMPLE_GEOJSON))
     tooltip = geojson_with_tooltip["features"][0]["properties"]["tooltip"]
     assert "<b>name<b>: Sample Point<br><b>type<b>: Point of Interest<br>" == tooltip
 
 
 def test_create_feature_toolip_no_tags():
     with pytest.raises(ValueError):
-        create_feature_toolip(SAMPLE_GEOJSON_NO_TAGS.copy())
+        create_feature_toolip(copy.deepcopy(SAMPLE_GEOJSON_NO_TAGS))
 
 
 def test_process_output_csv():
-    df = process_output_csv(SAMPLE_GEOJSON)
+    df = process_output_csv(copy.deepcopy(SAMPLE_GEOJSON))
     assert isinstance(df, pd.DataFrame)
     assert "latitude" in df.columns
     assert "longitude" in df.columns
@@ -94,7 +95,7 @@ def test_process_output_csv_no_features():
     "geojson, preserve_types, expected_output",
     [
         (
-            SAMPLE_GEOJSON.copy(),
+            copy.deepcopy(SAMPLE_GEOJSON),
             [],
             {
                 "type": "FeatureCollection",
@@ -127,7 +128,7 @@ def test_process_output_csv_no_features():
             },
         ),
         (
-            SAMPLE_GEOJSON.copy(),
+            copy.deepcopy(SAMPLE_GEOJSON),
             ["LineString"],
             {
                 "type": "FeatureCollection",
@@ -193,7 +194,7 @@ def test_calc_bbox_area():
     expected_area = (
         111**2
     )  # Calculated manually for sample coordinates assuming 1 deg lat ~= 111km
-    
+
     assert pytest.approx(area, 0.1) == expected_area
 
 

--- a/frontend/app/tests/test_infraxclimate_api.py
+++ b/frontend/app/tests/test_infraxclimate_api.py
@@ -128,6 +128,18 @@ def test_get_data_invalid_category(mock_conn):
                             SQL(", "),
                             Composed(
                                 [
+                                    SQL("ST_AsText(ST_Transform("),
+                                    Identifier("osm"),
+                                    SQL("."),
+                                    Identifier("infrastructure"),
+                                    SQL("."),
+                                    Identifier("geom"),
+                                    SQL(", %s), 3) AS geometry_wkt"),
+                                ]
+                            ),
+                            SQL(", "),
+                            Composed(
+                                [
                                     SQL("ST_X(ST_Centroid(ST_Transform("),
                                     Identifier("osm"),
                                     SQL("."),
@@ -185,7 +197,7 @@ def test_get_data_invalid_category(mock_conn):
                     ),
                 ]
             ),
-            [4326, 4326, 4326],
+            [4326, 4326, 4326, 4326],
         ),
         # Climate query test case 1 - Any climate argument that is None will result in no climate columns returned
         (
@@ -227,6 +239,18 @@ def test_get_data_invalid_category(mock_conn):
                             SQL(", "),
                             Composed(
                                 [
+                                    SQL("ST_AsText(ST_Transform("),
+                                    Identifier("osm"),
+                                    SQL("."),
+                                    Identifier("infrastructure"),
+                                    SQL("."),
+                                    Identifier("geom"),
+                                    SQL(", %s), 3) AS geometry_wkt"),
+                                ]
+                            ),
+                            SQL(", "),
+                            Composed(
+                                [
                                     SQL("ST_X(ST_Centroid(ST_Transform("),
                                     Identifier("osm"),
                                     SQL("."),
@@ -258,14 +282,12 @@ def test_get_data_invalid_category(mock_conn):
                                 ]
                             ),
                             SQL(", "),
-                            Composed(
-                                [Identifier("city"), SQL(".name AS city_name")]
-                            ),
+                            Composed([Identifier("city"), SQL(".name AS city_name")]),
                         ]
                     ),
                 ]
             ),
-            [4326, 4326, 4326],
+            [4326, 4326, 4326, 4326],
         ),
     ],
 )


### PR DESCRIPTION
Refactored to remove gdal dependancies (GeoPandas, Shapely, etc..) to cut down on complex dependancies and offload geospatial computation to PostGIS database. This keeps the app lightweight.